### PR TITLE
Fix the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,16 @@ julia:
 notifications:
     email: false
 before_install:
+    # The HEALPix libraries exist as packages for utopic
+    # (we can get these by building from source)
+    - sudo su -c "echo 'deb-src http://archive.ubuntu.com/ubuntu utopic main universe' >> /etc/apt/sources.list"
     - sudo apt-get update -qq -y
-    - sudo apt-get install libchealpix-dev -y
+    - sudo apt-get build-dep libchealpix0 -y
+    - sudo apt-get build-dep libchealpix-dev -y
+    - sudo apt-get -b source libchealpix0 -y
+    - sudo apt-get -b source libchealpix-dev -y
+    - sudo dpkg -i libchealpix0*.deb
+    - sudo dpkg -i libchealpix-dev*.deb
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia --check-bounds=yes -e "Pkg.clone(pwd()); Pkg.test(\"HEALPix\"; coverage=true)"


### PR DESCRIPTION
Because travis is on ubuntu precise, we need to download the source and
build the package from scratch.

There does seem to be an old ppa with the right packages
(https://launchpad.net/~zonca/+archive/ubuntu/healpix), but I couldn't
dlopen the shared library after installing from here. It was weird.

Debugging travis is on my top ten list of things I hate. This one took
28 tries to get right :(
