### PR TITLE
Building the C++ packages from scratch (using apt) takes almost 10 minutes each

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,9 @@ julia:
     - nightly
 notifications:
     email: false
-before_install:
-    # The HEALPix libraries exist as packages for utopic
-    # (we can get these by building from source)
-    - sudo su -c "echo 'deb-src http://archive.ubuntu.com/ubuntu utopic main universe' >> /etc/apt/sources.list"
-    - sudo apt-get update -qq -y
-    - sudo apt-get build-dep libchealpix0 -y
-    - sudo apt-get build-dep libchealpix-dev -y
-    - sudo apt-get -b source libchealpix0 -y
-    - sudo apt-get -b source libchealpix-dev -y
-    - sudo dpkg -i libchealpix0*.deb
-    - sudo dpkg -i libchealpix-dev*.deb
-    - sudo apt-get build-dep libhealpix-cxx0 -y
-    - sudo apt-get build-dep libhealpix-cxx-dev -y
-    - sudo apt-get -b source libhealpix-cxx0 -y
-    - sudo apt-get -b source libhealpix-cxx-dev -y
-    - sudo dpkg -i libhealpix-cxx0*.deb
-    - sudo dpkg -i libhealpix-cxx-dev*.deb
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia --check-bounds=yes -e "Pkg.clone(pwd()); Pkg.test(\"HEALPix\"; coverage=true)"
+    - julia --check-bounds=yes -e "Pkg.clone(pwd()); Pkg.build(\"HEALPix\"); Pkg.test(\"HEALPix\"; coverage=true)"
 after_success:
     - julia -e "cd(Pkg.dir(\"HEALPix\")); Pkg.add(\"Coverage\"); using Coverage; Coveralls.submit(Coveralls.process_folder())"
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,6 +10,7 @@ dir = joinpath(depsdir,"downloads")
 run(`mkdir -p $dir`)
 run(`curl -o $(joinpath(dir,gz)) -L $url`)
 run(`tar -xzf $(joinpath(dir,gz)) -C $dir`)
+run(`./build_healpix.sh`)
 
 # Build the HEALPix wrapper
 println("Building the HEALPix wrapper...")

--- a/deps/build_healpix.sh
+++ b/deps/build_healpix.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+HEALPIXDIR=downloads/Healpix_3.20
+
+cp config.gcc_with_fpic $HEALPIXDIR/src/cxx/config
+cd $HEALPIXDIR
+mkdir -p include
+mkdir -p lib
+
+# (the configure script says something goes wrong at the end, but it seems to work anyway)
+./configure -L << EOF
+2
+gcc
+-O2 -Wall
+ar -rsv
+n
+y
+n
+0
+EOF
+
+./configure -L << EOF
+4
+/usr/local/lib
+/usr/local/include
+2
+n
+0
+EOF
+
+make c-all
+make cpp-all
+

--- a/deps/config.gcc_with_fpic
+++ b/deps/config.gcc_with_fpic
@@ -1,0 +1,16 @@
+LS_OPTFLAGS:= -O2 -ffast-math -fno-tree-fre
+LS_DEBUGFLAGS:= #-g
+
+CC= gcc
+CL= gcc
+CCFLAGS_NO_C= $(LS_DEBUGFLAGS) $(LS_OPTFLAGS) -fno-strict-aliasing -std=c99 -fPIC
+CCFLAGS= $(CCFLAGS_NO_C) -c
+CLFLAGS= -L. -L$(LIBDIR) $(LS_OPTFLAGS) -lm
+
+CXX= g++
+CXXL= g++
+CXXCFLAGS_NO_C= $(LS_DEBUGFLAGS) $(LS_OPTFLAGS) -ansi -fPIC
+CXXCFLAGS= $(CXXCFLAGS_NO_C) -c
+CXXLFLAGS= -L. -L$(LIBDIR) $(LS_OPTFLAGS)
+
+ARCREATE= ar cr

--- a/deps/src/Makefile
+++ b/deps/src/Makefile
@@ -1,8 +1,9 @@
 CXX = g++
 CXXFLAGS = -c -Wall -Werror -fpic -Wno-unknown-pragmas
 
-HEALPIX = ../downloads/Healpix_3.20/src/cxx
-INCLUDES = -I$(HEALPIX)/Healpix_cxx -I$(HEALPIX)/cxxsupport
+HEALPIX = ../downloads/Healpix_3.20
+INCLUDES = -I$(HEALPIX)/src/cxx/Healpix_cxx -I$(HEALPIX)/src/cxx/cxxsupport
+LIBRARIES = -L$(HEALPIX)/lib -L$(HEALPIX)/src/cxx/gcc_with_fpic/lib -lhealpix_cxx -lcxxsupport -lsharp -lc_utils -lfftpack
 
 all: libhealpixwrapper.so
 
@@ -10,7 +11,7 @@ transforms.o: transforms.cpp
 	$(CXX) $(CXXFLAGS) transforms.cpp $(INCLUDES)
 
 libhealpixwrapper.so: transforms.o
-	$(CXX) -shared -o libhealpixwrapper.so transforms.o -lhealpix_cxx -lcxxsupport -lsharp -lc_utils -lfftpack
+	$(CXX) -shared -o libhealpixwrapper.so transforms.o $(LIBRARIES)
 
 clean:
 	-rm *.o

--- a/src/HEALPix.jl
+++ b/src/HEALPix.jl
@@ -19,7 +19,7 @@ export HEALPixMap
 
 import Base: length, getindex, setindex!
 
-const libchealpix = "libchealpix"
+const libchealpix = joinpath(dirname(@__FILE__),"../deps/downloads/Healpix_3.20/lib/libchealpix.so")
 const libhealpixwrapper = joinpath(dirname(@__FILE__),"../deps/libhealpixwrapper.so")
 
 const UNDEF = -1.6375e30 # Defined by the Healpix standard


### PR DESCRIPTION
This is mostly due to apt running the tests. So let's build HEALPix
using my own build script.
