### PR TITLE
Add support for reading/writing HEALPix maps in FITS format

### DIFF
--- a/deps/build_healpix.sh
+++ b/deps/build_healpix.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 HEALPIXDIR=downloads/Healpix_3.20
 
@@ -7,19 +7,24 @@ cd $HEALPIXDIR
 mkdir -p include
 mkdir -p lib
 
-# (the configure script says something goes wrong at the end, but it seems to work anyway)
-./configure -L << EOF
+# patch the configure script to search the correct directory on Travis
+patch hpxconfig_functions.sh ../../hpxconfig_functions.patch
+
+bash ./configure -L << EOF
 2
 gcc
 -O2 -Wall
 ar -rsv
-n
+y
+
+
+
 y
 n
 0
 EOF
 
-./configure -L << EOF
+bash ./configure -L << EOF
 4
 
 
@@ -27,6 +32,9 @@ EOF
 n
 0
 EOF
+
+# patch the C Makefile to link libcfitsio into libchealpix
+patch src/C/subs/Makefile ../../src_C_subs_Makefile.patch
 
 make c-all
 make cpp-all

--- a/deps/hpxconfig_functions.patch
+++ b/deps/hpxconfig_functions.patch
@@ -1,0 +1,11 @@
+--- downloads/Healpix_3.20/hpxconfig_functions.sh	2015-06-22 21:21:21.503470248 -0700
++++ downloads/Healpix_3.20/hpxconfig_functions_patched.sh	2015-06-22 21:21:25.200955182 -0700
+@@ -85,7 +85,7 @@
+ }
+ #-------------
+ findFITSLib () {
+-    for dir in $* /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64 /usr/local/lib/cfitsio /usr/local/lib64/cftisio /usr/local/src/cfitsio ${HOME}/lib ${HOME}/lib64 ./src/cxx/${HEALPIX_TARGET}/lib/ /softs/cfitsio/3.24/lib /usr/common/usg/cfitsio/3.26/lib ; do
++    for dir in $* /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64 /usr/local/lib/cfitsio /usr/local/lib64/cftisio /usr/local/src/cfitsio ${HOME}/lib ${HOME}/lib64 ./src/cxx/${HEALPIX_TARGET}/lib/ /softs/cfitsio/3.24/lib /usr/common/usg/cfitsio/3.26/lib /usr/lib/i386-linux-gnu /usr/lib/x86_64-linux-gnu ; do
+ 	if [ -r "${dir}/lib${LIBFITS}.a" -o -r "${dir}/lib${LIBFITS}.so" -o -r "${dir}/lib${LIBFITS}.dylib" ] ; then
+ 	    FITSDIR=$dir
+ 	    break

--- a/deps/src_C_subs_Makefile.patch
+++ b/deps/src_C_subs_Makefile.patch
@@ -1,0 +1,11 @@
+--- downloads/Healpix_3.20/src/C/subs/Makefile	2015-06-22 21:25:10.144663170 -0700
++++ downloads/Healpix_3.20/src/C/subs/Makefile_patched	2015-06-22 21:24:35.913805309 -0700
+@@ -107,7 +107,7 @@
+ shared: libchealpix$(SHLIB_SUFFIX) #tests
+ 
+ libchealpix$(SHLIB_SUFFIX) : $(OBJD)
+-	$(SHLIB_LD) -o $@ $(OBJD)
++	$(SHLIB_LD) -o $@ $(OBJD) $(CFITSIO_LIBS)
+ 
+ # Make the dynamic (Mac) library itself
+ dynamic: libchealpix$(DYLIB_SUFFIX) #tests

--- a/src/HEALPix.jl
+++ b/src/HEALPix.jl
@@ -19,6 +19,7 @@ export HEALPixMap, pixels, nside, npix, nring, isring, isnest
 export Alm, coefficients, lmax, mmax
 export npix2nside, nside2npix
 export map2alm, alm2map
+export writehealpix, readhealpix
 export mollweide
 
 import Base: length, getindex, setindex!, pointer

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,10 +27,22 @@ let nside = 16
     map = HEALPixMap(rand(npix))
     alm = map2alm(map,lmax=25,mmax=25)
 
-    # Note that the algorithm used by alm2map/map2alm isn't particularly accurate
-    # (hence the rough tolerance)
+    # Note that the algorithm used by alm2map/map2alm isn't
+    # particularly accurate, hence the rough tolerance
     map1 = alm2map(alm)
     map2 = alm2map(map2alm(map1))
     @test vecnorm(HEALPix.pixels(map1)-HEALPix.pixels(map2))/vecnorm(HEALPix.pixels(map1)) < 0.01
+end
+
+# Test FITS I/O
+let nside = 16
+    filename = tempname()*".fits"
+    map = HEALPixMap(Float32,nside)
+    for i = 1:length(map)
+        map[i] = rand()
+    end
+    writehealpix(filename,map)
+    newmap = readhealpix(filename)
+    @test map == newmap
 end
 


### PR DESCRIPTION
The two patches make sure configure finds libcfitsio.a on Travis and links libcfitsio while building libchealpix.so to avoid undefined symbols.
