### PR TITLE
Build the package in OSX 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: julia
+os:
+    - linux
+    - osx
 julia:
     - 0.4
     - nightly
 notifications:
     email: false
 before_install:
-    - sudo apt-get install libcfitsio3-dev -y
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libcfitsio3-dev -y; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cfitsio; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -s /usr/local/bin/gcc-4.9 /usr/local/bin/gcc; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -s /usr/local/bin/g++-4.9 /usr/local/bin/g++; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=/usr/local/bin:$PATH; fi
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia --check-bounds=yes -e "Pkg.clone(pwd()); Pkg.build(\"LibHealpix\"); Pkg.test(\"LibHealpix\"; coverage=true)"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ using LibHealpix
 
 The build process will attempt to download and build the [Healpix](http://healpix.jpl.nasa.gov/) library.
 
+###### Issues of building in OSX
+In OSX, by default, `gcc` and `g++` are linked to *Clang*, which does not supported some of the flags used to build the [Healpix](http://healpix.jpl.nasa.gov/) library and wrappers in this package. A quick fix could be to link `gcc` and `g++` to *GNU gcc/g++*.
+
 ## Examples
 
 ### Creating a Map
@@ -68,4 +71,3 @@ imshow(img)
 ## Development
 This package is very much a work in progress. Only a small part of the Healpix library is currently wrapped.
 Please open issues or pull requests for missing functionality.
-

--- a/deps/src/alm.cpp
+++ b/deps/src/alm.cpp
@@ -28,7 +28,7 @@ extern "C" {
         size_t nalm = num_alm(lmax,mmax);
         // Pack the alms into Healpix's arr container
         arr<xcomplex<double> > arr_alm(num_alm(lmax,mmax));
-        for (uint i = 0; i < nalm; ++i)
+        for (size_t i = 0; i < nalm; ++i)
             arr_alm[i] = xcomplex<double>(vec_alm[i]);
         // Create the Alm container
         Alm<xcomplex<double> >* alm = new Alm<xcomplex<double> >(lmax,mmax);
@@ -39,7 +39,7 @@ extern "C" {
     void alm2julia(Alm<xcomplex<double> >* alm, complex<double>* output)
     {
         arr<xcomplex<double> > arr_alm = alm->Alms();
-        for (uint i = 0; i < arr_alm.size(); ++i)
+        for (size_t i = 0; i < arr_alm.size(); ++i)
             output[i] = arr_alm[i];
     }
     int lmax(Alm<xcomplex<double> >* alm) {return alm->Lmax();}

--- a/deps/src/map.cpp
+++ b/deps/src/map.cpp
@@ -22,7 +22,7 @@ extern "C" {
         size_t npix = 12*nside*nside;
         // Pack the pixel values into Healpix's arr container
         arr<double> arr_map(npix);
-        for (uint i = 0; i < npix; ++i)
+        for (size_t i = 0; i < npix; ++i)
             arr_map[i] = vec_map[i];
         // Create the Healpix_Map container
         Healpix_Map<double>* map = new Healpix_Map<double>(arr_map,RING);

--- a/src/LibHealpix.jl
+++ b/src/LibHealpix.jl
@@ -28,7 +28,7 @@ importall Base.Operators
 import Base: length, pointer
 
 function __init__()
-    global const libchealpix = joinpath(dirname(@__FILE__),"../deps/downloads/Healpix_3.20/lib/libchealpix.so")
+    global const libchealpix = joinpath(dirname(@__FILE__),"../deps/downloads/Healpix_3.20/lib/libchealpix")
     global const libhealpixwrapper = joinpath(dirname(@__FILE__),"../deps/libhealpixwrapper.so")
 end
 


### PR DESCRIPTION
Refer to the issue #10.
It is a minimal fix for building the package in OSX. I just change some types and paths so that it is more robust to different performs.

One needs to build the package with a working GNU gcc/g++ linked to default `gcc` and `g++`. To do it, a simple way is to use Homebrew. Install GNU gcc/g++ in Homebrew. Create symlinks (since Homebrew would name the gcc/g++ binary with the versions installed, say, `gcc-5` or `gcc-4.9`). Make sure the directory for packages installed by Homebrew is at the front of `PATH`. 

``` bash
brew install gcc
ln -s /usr/local/bin/gcc-5 /usr/local/bin/gcc
ln -s /usr/local/bin/g++-5 /usr/local/bin/g++
export PATH=/usr/local/bin:$PATH
```

I put similar codes in `.travis.yml` so that it works in the Travis-CI build in OSX. Travis-CI's OSX already has gcc-4.9 installed with Homebrew. So I just make the symlinks and `PATH`.

It is far from ideal, though. I believe the package should be able to build with Clang.
