### PR TITLE
wrap iterative map2alm, minor bug fixes, minor formatting changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,11 @@
 To get started using LibHealpix, run:
 ```julia
 Pkg.add("LibHealpix")
-Pkg.build("LibHealpix")
 Pkg.test("LibHealpix")
 using LibHealpix
 ```
 
-The build process will attempt to download and build the [Healpix](http://healpix.jpl.nasa.gov/) library.
-
-###### Issues of building in OSX
-In OSX, by default, `gcc` and `g++` are linked to *Clang*, which does not supported some of the flags used to build the [Healpix](http://healpix.jpl.nasa.gov/) library and wrappers in this package. A quick fix could be to link `gcc` and `g++` to *GNU gcc/g++*.
+The build process will attempt to download and build the [Healpix](http://healpix.sourceforge.net) library.
 
 ## Examples
 
@@ -31,7 +27,7 @@ In OSX, by default, `gcc` and `g++` are linked to *Clang*, which does not suppor
 ```julia
 using LibHealpix
 nside = 16
-map = HealpixMap(Float64,nside)
+map = HealpixMap(Float64, nside)
 for i = 1:length(map)
     map[i] = i
 end
@@ -41,26 +37,27 @@ end
 ```julia
 using LibHealpix
 lmax = mmax = 10
-alm = Alm(Complex128,lmax,mmax)
+alm = Alm(Complex128, lmax, mmax)
 for m = 0:mmax, l = m:lmax
     alm[l,m] = l + m
 end
-map = alm2map(alm,nside=16)
-blm = map2alm(map,lmax=20,mmax=20)
+nside = 16
+map = alm2map(alm, nside)
+blm = map2alm(map, lmax, mmax)
 ```
 
 ### FITS I/O
 ```julia
 using LibHealpix
 map = readhealpix("map.fits")
-writehealpix("othermap.fits",map)
+writehealpix("othermap.fits", map)
 ```
 
 ### Visualization
 ```julia
 using LibHealpix
 using PyPlot # for imshow(...)
-map = HealpixMap(Float64,nside)
+map = HealpixMap(Float64, nside)
 for i = 1:length(map)
     map[i] = rand()
 end
@@ -71,3 +68,4 @@ imshow(img)
 ## Development
 This package is very much a work in progress. Only a small part of the Healpix library is currently wrapped.
 Please open issues or pull requests for missing functionality.
+

--- a/deps/src/map.cpp
+++ b/deps/src/map.cpp
@@ -17,7 +17,7 @@
 #include <healpix_map.h>
 
 extern "C" {
-    Healpix_Map<double>* newMap(double* vec_map, size_t nside)
+    Healpix_Map<double>* newMap(double* vec_map, size_t nside, int order)
     {
         size_t npix = 12*nside*nside;
         // Pack the pixel values into Healpix's arr container
@@ -25,7 +25,8 @@ extern "C" {
         for (size_t i = 0; i < npix; ++i)
             arr_map[i] = vec_map[i];
         // Create the Healpix_Map container
-        Healpix_Map<double>* map = new Healpix_Map<double>(arr_map,RING);
+        Healpix_Ordering_Scheme scheme = static_cast<Healpix_Ordering_Scheme>(order);
+        Healpix_Map<double>* map = new Healpix_Map<double>(arr_map, scheme);
         return map;
     }
     void deleteMap(Healpix_Map<double>* map) {delete map;}
@@ -36,5 +37,6 @@ extern "C" {
     }
     int nside(Healpix_Map<double>* map) {return map->Nside();}
     int npix(Healpix_Map<double>* map) {return map->Npix();}
+    int order(Healpix_Map<double>* map) {return map->Scheme();}
 }
 

--- a/deps/src/transforms.cpp
+++ b/deps/src/transforms.cpp
@@ -18,10 +18,10 @@
 #include <alm_healpix_tools.h>
 
 extern "C" {
-    void map2alm(Healpix_Map<double>* map, Alm<xcomplex<double> >* alm)
+    void map2alm(Healpix_Map<double>* map, Alm<xcomplex<double> >* alm, int num_iter)
     {
         arr<double> weight(2*map->Nside(),1.0);
-        map2alm(*map,*alm,weight);
+        map2alm_iter(*map,*alm,num_iter,weight);
     }
 
     void alm2map(Alm<xcomplex<double> >* alm, Healpix_Map<double>* map)

--- a/src/alm.jl
+++ b/src/alm.jl
@@ -14,16 +14,24 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-    Alm{T<:Complex,lmax,mmax}
+    Alm{T<:Complex, lmax, mmax}
 
 This type holds a vector of spherical harmonic coefficients.
 
 Construction of this type will throw a `DomainError` exception if `mmax > lmax`.
 A `DimensionMismatch` exception will be thrown if the provided
 list of coefficients is not the correct length.
+
+    Alm(lmax, mmax, coefficients)
+
+Construct an `Alm` object with the given list of coefficients.
+
+    Alm(T, lmax, mmax)
+
+Construct an `Alm` object where all the coefficients are initialized to `zero(T)`.
 """
 immutable Alm{T<:Complex,lmax,mmax}
-    alm::Vector{T}
+    alm :: Vector{T}
     function Alm(vec)
         lmax ≥ mmax || throw(DomainError())
         N = num_alm(lmax,mmax)
@@ -32,95 +40,83 @@ immutable Alm{T<:Complex,lmax,mmax}
     end
 end
 
-"""
-    Alm(lmax,mmax,coefficients)
-
-Construct an `Alm` object with the given list of coefficients.
-"""
 Alm{T}(lmax::Int,mmax::Int,vec::Vector{T}) = Alm{T,lmax,mmax}(vec)
-"""
-    Alm(T,lmax,mmax)
-
-Construct an `Alm` object where all the coefficients are initialized to `zero(T)`.
-"""
 Alm{T}(::Type{T},lmax::Int,mmax::Int) = Alm{T,lmax,mmax}(zeros(T,num_alm(lmax,mmax)))
 
 """
-    num_alm(lmax,mmax)
+    num_alm(lmax, mmax)
 
 Compute the number of spherical harmonic coefficients with `l ≤ lmax`
 and `m ≤ mmax`.
 """
-function num_alm(lmax::Csize_t,mmax::Csize_t)
+function num_alm(lmax::Csize_t, mmax::Csize_t)
     lmax ≥ mmax || throw(DomainError())
-    ccall(("num_alm",libhealpixwrapper),Csize_t,
-          (Csize_t,Csize_t),lmax,mmax)
+    ccall(("num_alm", libhealpixwrapper), Csize_t, (Csize_t, Csize_t), lmax, mmax)
 end
 num_alm(lmax,mmax) = num_alm(Csize_t(lmax),Csize_t(mmax))
 
 coefficients(alm::Alm) = alm.alm
 length(alm::Alm) = length(coefficients(alm))
-getindex(alm::Alm,i) = coefficients(alm)[i]
-setindex!(alm::Alm,x,i) = coefficients(alm)[i] = x
+getindex(alm::Alm, i) = coefficients(alm)[i]
+setindex!(alm::Alm, x, i) = coefficients(alm)[i] = x
 
-lmax{T,l,m}(alm::Alm{T,l,m}) = l
-mmax{T,l,m}(alm::Alm{T,l,m}) = m
+lmax{T, l, m}(alm::Alm{T, l, m}) = l
+mmax{T, l, m}(alm::Alm{T, l, m}) = m
 
-function getindex(alm::Alm,l,m)
+function getindex(alm::Alm, l, m)
     absm = abs(m)
-    output = getindex(alm,div(absm*(2lmax(alm)-absm+3),2)+l-absm+1)
+    output = alm[div(absm*(2lmax(alm)-absm+3),2)+l-absm+1]
     ifelse(m ≥ 0, output, (-1)^absm*conj(output))
 end
 
-function setindex!(alm::Alm,x,l,m)
+function setindex!(alm::Alm, x, l, m)
     absm = abs(m)
     x = ifelse(m ≥ 0, x, (-1)^absm*conj(x))
-    setindex!(alm,x,div(absm*(2lmax(alm)-absm+3),2)+l-absm+1)
+    alm[div(absm*(2lmax(alm)-absm+3),2)+l-absm+1] = x
 end
 
 for op in (:+,:-)
-    @eval $op(lhs::Alm,rhs::Alm) = Alm(lmax(lhs),mmax(lhs),$op(coefficients(lhs),coefficients(rhs)))
+    @eval function $op(lhs::Alm, rhs::Alm)
+        Alm(lmax(lhs), mmax(lhs), $op(coefficients(lhs), coefficients(rhs)))
+    end
 end
 
-*(lhs::Number,rhs::Alm) = Alm(lmax(rhs),mmax(rhs),lhs*coefficients(rhs))
-*(lhs::Alm,rhs::Number) = rhs*lhs
+*(lhs::Number, rhs::Alm) = Alm(lmax(rhs), mmax(rhs), lhs * coefficients(rhs))
+*(lhs::Alm, rhs::Number) = rhs * lhs
 
 ################################################################################
 # C++ wrapper methods
 
 type Alm_cxx
-    ptr::Ptr{Void}
+    ptr :: Ptr{Void}
 end
+
+Base.unsafe_convert(::Type{Ptr{Void}}, alm_cxx::Alm_cxx) = alm_cxx.ptr
 
 function delete(alm_cxx::Alm_cxx)
-    ccall(("deleteAlm",libhealpixwrapper),Void,
-          (Ptr{Void},),pointer(alm_cxx))
+    ccall(("deleteAlm",libhealpixwrapper), Void, (Ptr{Void},), alm_cxx)
 end
 
-pointer(alm_cxx::Alm_cxx) = alm_cxx.ptr
-
 for f in (:lmax,:mmax)
-    @eval $f(alm_cxx::Alm_cxx) = ccall(($(string(f)),libhealpixwrapper),Cint,(Ptr{Void},),pointer(alm_cxx))
+    @eval function $f(alm_cxx::Alm_cxx)
+        ccall(($(string(f)), libhealpixwrapper), Cint, (Ptr{Void},), alm_cxx)
+    end
 end
 
 function to_cxx(alm::Alm)
     l = lmax(alm)
     m = mmax(alm)
-    alm_cxx = Alm_cxx(ccall(("newAlm",libhealpixwrapper),Ptr{Void},
-                            (Ptr{Complex128},Csize_t,Csize_t),
-                            pointer(coefficients(alm)),Csize_t(l),Csize_t(m)))
-    finalizer(alm_cxx,delete)
+    alm_cxx = ccall(("newAlm", libhealpixwrapper), Ptr{Void}, (Ptr{Complex128}, Csize_t, Csize_t),
+                    coefficients(alm), l, m) |> Alm_cxx
+    finalizer(alm_cxx, delete)
     alm_cxx
 end
 
 function to_julia(alm_cxx::Alm_cxx)
     l = lmax(alm_cxx)
     m = mmax(alm_cxx)
-    N = num_alm(l,m)
-    output = Array{Complex128}(N)
-    ccall(("alm2julia",libhealpixwrapper),Void,
-          (Ptr{Void},Ptr{Complex128}),
-          pointer(alm_cxx),pointer(output))
-    Alm(Int(l),Int(m),output)
+    coef = Array{Complex128}(num_alm(l, m))
+    ccall(("alm2julia", libhealpixwrapper), Void, (Ptr{Void},Ptr{Complex128}), alm_cxx, coef)
+    Alm(Int(l), Int(m), coef)
 end
 

--- a/src/alm.jl
+++ b/src/alm.jl
@@ -84,6 +84,10 @@ end
 *(lhs::Number, rhs::Alm) = Alm(lmax(rhs), mmax(rhs), lhs * coefficients(rhs))
 *(lhs::Alm, rhs::Number) = rhs * lhs
 
+function ==(lhs::Alm, rhs::Alm)
+    lmax(lhs) == lmax(rhs) && mmax(lhs) == mmax(rhs) && coefficients(lhs) == coefficients(rhs)
+end
+
 ################################################################################
 # C++ wrapper methods
 

--- a/src/map.jl
+++ b/src/map.jl
@@ -163,8 +163,8 @@ end
 function to_cxx(map::HealpixMap)
     N = nside(map)
     map_cxx = HealpixMap_cxx(ccall(("newMap",libhealpixwrapper),Ptr{Void},
-                                   (Ptr{Complex128},Csize_t),
-                                   pointer(pixels(map)),Csize_t(N)))
+                                   (Ptr{Cdouble},Csize_t),
+                                   pixels(map),Csize_t(N)))
     finalizer(map_cxx,delete)
     map_cxx
 end

--- a/src/map.jl
+++ b/src/map.jl
@@ -86,8 +86,8 @@ for op in (:+,:-,:.*,:./)
     @eval $op(lhs::HealpixMap, rhs::HealpixMap) = HealpixMap($op(pixels(lhs), pixels(rhs)))
 end
 
-*(lhs::Number, rhs::HealpixMap) = HealpixMap(lhs * pixels(rhs))
-*(lhs::HealpixMap, rhs::Number) = rhs * lhs
+*(lhs::Real, rhs::HealpixMap) = HealpixMap(lhs * pixels(rhs))
+*(lhs::HealpixMap, rhs::Real) = rhs * lhs
 
 function ==(lhs::HealpixMap, rhs::HealpixMap)
     nside(lhs) == nside(rhs) && isring(lhs) == isring(rhs) && pixels(lhs) == pixels(rhs)

--- a/src/map.jl
+++ b/src/map.jl
@@ -145,7 +145,7 @@ end
 # C++ wrapper methods
 
 type HealpixMap_cxx
-    ptr::Ptr{Void}
+    ptr :: Ptr{Void}
 end
 
 Base.unsafe_convert(::Type{Ptr{Void}}, map_cxx::HealpixMap_cxx) = map_cxx.ptr
@@ -172,7 +172,6 @@ function to_cxx(map::HealpixMap)
 end
 
 function to_julia(map_cxx::HealpixMap_cxx)
-    # TODO: check and propagate the ordering of the C++ map
     pix = Array{Cdouble}(npix(map_cxx))
     ccall(("map2julia", libhealpixwrapper), Void, (Ptr{Void}, Ptr{Cdouble}), map_cxx, pix)
     HealpixMap(pix, order(map_cxx))

--- a/src/map.jl
+++ b/src/map.jl
@@ -112,12 +112,9 @@ function writehealpix(filename, map::HealpixMap; coordsys::ASCIIString = "C", re
         end
     end
     pix = Vector{Cfloat}(pixels(map))
-    out = ccall(("write_healpix_map", libchealpix), Cint,
-                (Ptr{Cfloat}, Clong, Cstring, Cchar, Cstring),
-                pix, nside(map), filename, isnest(map), coordsys)
-    if out != 0
-        error("Error writing $filename ($out).")
-    end
+    ccall(("write_healpix_map", libchealpix), Void,
+          (Ptr{Cfloat}, Clong, Cstring, Cchar, Cstring),
+          pix, nside(map), filename, isnest(map), coordsys)
 end
 
 """

--- a/src/mollweide.jl
+++ b/src/mollweide.jl
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-    mollweide(map::HEALPixMap)
+    mollweide(map::HealpixMap)
 
 Create an image of the map through the use of a Mollweide projection.
 The image will be zero in the region outside of the projection area.

--- a/src/pixel.jl
+++ b/src/pixel.jl
@@ -16,74 +16,75 @@
 ################################################################################
 # Pixel operations
 
-for T in (:Clong,:Clonglong)
+types = (Clong == Clonglong)? (:Clong,) : (:Clong, :Clonglong)
+for T in types
     # Append "64" to the ccall function name when defining for Clonglong
     # (note we omit this suffix from the Julia function name -- just let dispatch take care of it)
-    funcname(f) = (T==:Clong)? string(f) : string(f)*"64"
+    funcname(f) = (T == :Clong)? string(f) : string(f)*"64"
 
-    for f in (:ang2pix_nest,:ang2pix_ring)
-        @eval function $f(nside::$T,θ::Cdouble,ϕ::Cdouble)
-            ipixptr = Array($T,1)
-            0 <= θ <= π || error("θ is out of range")
-            ccall(($(funcname(f)),libchealpix),Void,($T,Cdouble,Cdouble,Ptr{$T}),nside,θ,ϕ,ipixptr)
-            ipixptr[1] + 1 # Add one to convert to a 1-indexed scheme
+    for f in (:ang2pix_nest, :ang2pix_ring)
+        @eval function $f(nside::$T, θ::Cdouble, ϕ::Cdouble)
+            ipixptr = Ref{$T}(0)
+            0 ≤ θ ≤ π || error("θ is out of range")
+            ccall(($(funcname(f)), libchealpix), Void, ($T, Cdouble, Cdouble, Ref{$T}), nside, θ, ϕ, ipixptr)
+            ipixptr[] + 1 # Add one to convert to a 1-indexed scheme
         end
     end
 
-    for f in (:pix2ang_nest,:pix2ang_ring)
-        @eval function $f(nside::$T,ipix::$T)
+    for f in (:pix2ang_nest, :pix2ang_ring)
+        @eval function $f(nside::$T, ipix::$T)
             ipix -= 1 # Subtract one to convert back to a 0-indexed scheme
-            θptr = Array(Cdouble,1)
-            ϕptr = Array(Cdouble,1)
-            ccall(($(funcname(f)),libchealpix),Void,($T,$T,Ptr{Cdouble},Ptr{Cdouble}),nside,ipix,θptr,ϕptr)
-            θptr[1],ϕptr[1]
+            θptr = Ref{Cdouble}(0.0)
+            ϕptr = Ref{Cdouble}(0.0)
+            ccall(($(funcname(f)), libchealpix), Void, ($T, $T, Ref{Cdouble}, Ref{Cdouble}), nside, ipix, θptr, ϕptr)
+            θptr[], ϕptr[]
         end
     end
 
-    for f in (:nest2ring,:ring2nest)
-        @eval function $f(nside::$T,ipix::$T)
+    for f in (:nest2ring, :ring2nest)
+        @eval function $f(nside::$T, ipix::$T)
             ipix -= 1 # Subtract one to convert back to a 0-indexed scheme
-            ipixoutptr = Array($T,1)
-            ccall(($(funcname(f)),libchealpix),Void,($T,$T,Ptr{$T}),nside,ipix,ipixoutptr)
-            ipixoutptr[1] + 1 # Add one to convert to a 1-indexed scheme
+            ipixoutptr = Ref{$T}(0)
+            ccall(($(funcname(f)), libchealpix), Void, ($T, $T, Ref{$T}), nside, ipix, ipixoutptr)
+            ipixoutptr[] + 1 # Add one to convert to a 1-indexed scheme
         end
     end
 
-    for f in (:nside2npix,:npix2nside)
-        @eval $f(x::$T) = ccall(($(funcname(f)),libchealpix),$T,($T,),x)
+    for f in (:nside2npix, :npix2nside)
+        @eval $f(x::$T) = ccall(($(funcname(f)), libchealpix), $T, ($T,), x)
     end
 
-    for f in (:vec2pix_nest,:vec2pix_ring)
-        @eval function $f(nside::$T,vec::Vector{Cdouble})
-            ipixptr = Array($T,1)
-            ccall(($(funcname(f)),libchealpix),Void,($T,Ptr{Cdouble},Ptr{$T}),nside,vec,ipixptr)
-            ipixptr[1] + 1 # Add one to convert to a 1-indexed scheme
+    for f in (:vec2pix_nest, :vec2pix_ring)
+        @eval function $f(nside::$T, vec::Vector{Cdouble})
+            ipixptr = Ref{$T}(0)
+            ccall(($(funcname(f)), libchealpix), Void, ($T, Ptr{Cdouble}, Ref{$T}), nside, vec, ipixptr)
+            ipixptr[] + 1 # Add one to convert to a 1-indexed scheme
         end
     end
 
-    for f in (:pix2vec_nest,:pix2vec_ring)
-        @eval function $f(nside::$T,ipix::$T)
+    for f in (:pix2vec_nest, :pix2vec_ring)
+        @eval function $f(nside::$T, ipix::$T)
             ipix -= 1 # Subtract one to convert back to a 0-indexed scheme
             vec = Array(Cdouble,3)
-            ccall(($(funcname(f)),libchealpix),Void,($T,$T,Ptr{Cdouble}),nside,ipix,vec)
+            ccall(($(funcname(f)), libchealpix), Void, ($T, $T, Ptr{Cdouble}), nside, ipix, vec)
             vec
         end
     end
 end
 
-function ang2vec(θ::Cdouble,ϕ::Cdouble)
+function ang2vec(θ::Cdouble, ϕ::Cdouble)
     vec = Array(Cdouble,3)
-    ccall(("ang2vec",libchealpix),Void,(Cdouble,Cdouble,Ptr{Cdouble}),θ,ϕ,vec)
+    ccall(("ang2vec", libchealpix), Void, (Cdouble, Cdouble, Ptr{Cdouble}), θ, ϕ, vec)
     vec
 end
 
 function vec2ang(vec::Vector{Cdouble})
-    θptr = Array(Cdouble,1)
-    ϕptr = Array(Cdouble,1)
-    ccall(("vec2ang",libchealpix),Void,(Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),vec,θptr,ϕptr)
-    θptr[1],ϕptr[1]
+    θptr = Ref{Cdouble}(0.0)
+    ϕptr = Ref{Cdouble}(0.0)
+    ccall(("vec2ang", libchealpix), Void, (Ptr{Cdouble}, Ref{Cdouble}, Ref{Cdouble}), vec, θptr, ϕptr)
+    θptr[], ϕptr[]
 end
 
-npix2nside(npix) = npix2nside(Clong(npix))
-nside2npix(nside) = nside2npix(Clong(nside))
+npix2nside(npix) = npix2nside(Int(npix))
+nside2npix(nside) = nside2npix(Int(nside))
 

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -13,24 +13,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-function map2alm(map::HealpixMap;lmax::Int=100,mmax::Int=100)
+function map2alm(map::HealpixMap, lmax::Int, mmax::Int; iterations::Int=0)
     isring(map) || error("The input HealpixMap must have ring ordering.")
-    nalm = num_alm(lmax,mmax)
+    nalm = num_alm(lmax, mmax)
     map_cxx = map |> to_cxx
-    alm_cxx = Alm(lmax,mmax,zeros(Complex128,nalm)) |> to_cxx
-    ccall(("map2alm",libhealpixwrapper),Void,
-          (Ptr{Void},Ptr{Void}),
-          pointer(map_cxx),pointer(alm_cxx))
+    alm_cxx = Alm(lmax, mmax, zeros(Complex128, nalm)) |> to_cxx
+    ccall(("map2alm",libhealpixwrapper), Void, (Ptr{Void}, Ptr{Void}, Cint), map_cxx, alm_cxx, iterations)
     alm_cxx |> to_julia
 end
 
-function alm2map(alm::Alm;nside::Int=32)
+function alm2map(alm::Alm, nside::Int)
     npix = nside2npix(nside)
     alm_cxx = alm |> to_cxx
-    map_cxx = HealpixMap(zeros(Cdouble,npix)) |> to_cxx
-    ccall(("alm2map",libhealpixwrapper),Void,
-          (Ptr{Void},Ptr{Void}),
-          pointer(alm_cxx),pointer(map_cxx))
+    map_cxx = HealpixMap(zeros(Cdouble, npix)) |> to_cxx
+    ccall(("alm2map", libhealpixwrapper), Void, (Ptr{Void}, Ptr{Void}), alm_cxx, map_cxx)
     map_cxx |> to_julia
 end
+
+@deprecate map2alm(map; lmax=100, mmax=100) map2alm(map, lmax, mmax)
+@deprecate alm2map(alm; nside=32) alm2map(alm, nside)
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+BaseTestNext

--- a/test/alm.jl
+++ b/test/alm.jl
@@ -10,20 +10,31 @@
         alm = Alm{Complex128,lmax′,mmax′}(zeros(Complex128,N))
         @test lmax(alm) == lmax′
         @test mmax(alm) == mmax′
+        @test length(alm) == length(coefficients(alm)) == LibHealpix.num_alm(lmax′,mmax′)
 
         alm = Alm(Complex128,lmax′,mmax′)
         @test lmax(alm) == lmax′
         @test mmax(alm) == mmax′
         @test coefficients(alm) == zeros(Complex128,N)
-        alm[0,0] = 1
-        @test alm[0,0] == coefficients(alm)[1] == 1
+        @test length(alm) == length(coefficients(alm)) == LibHealpix.num_alm(lmax′,mmax′)
+    end
 
+    let lmax = 10, mmax = 5
+        N = LibHealpix.num_alm(lmax,mmax)
+        alm = Alm(Complex128,lmax,mmax)
+        alm[0,0] = 1
+        @test alm[0,0] == alm[1] == coefficients(alm)[1] == 1
+        alm[2] = 2
+        @test alm[1,0] == alm[2] == coefficients(alm)[2] == 2
+
+        a = rand(Complex128)
         x = complex(rand(N),rand(N))
         y = complex(rand(N),rand(N))
-        alm1 = Alm(lmax′,mmax′,x)
-        alm2 = Alm(lmax′,mmax′,y)
+        alm1 = Alm(lmax,mmax,x)
+        alm2 = Alm(lmax,mmax,y)
         @test coefficients(alm1+alm2) == x+y
         @test coefficients(alm1-alm2) == x-y
+        @test coefficients(a*alm1) == coefficients(alm1*a) == a*x
     end
 
     let

--- a/test/alm.jl
+++ b/test/alm.jl
@@ -1,0 +1,36 @@
+@testset "alm.jl" begin
+    let
+        @test_throws DomainError Alm{Complex128,5,10}(zeros(Complex128,5))
+        @test_throws DimensionMismatch Alm{Complex128,10,5}(zeros(Complex128,5))
+
+        lmax′ = 10
+        mmax′ = 5
+        N = LibHealpix.num_alm(lmax′,mmax′)
+
+        alm = Alm{Complex128,lmax′,mmax′}(zeros(Complex128,N))
+        @test lmax(alm) == lmax′
+        @test mmax(alm) == mmax′
+
+        alm = Alm(Complex128,lmax′,mmax′)
+        @test lmax(alm) == lmax′
+        @test mmax(alm) == mmax′
+        @test coefficients(alm) == zeros(Complex128,N)
+        alm[0,0] = 1
+        @test alm[0,0] == coefficients(alm)[1] == 1
+
+        x = complex(rand(N),rand(N))
+        y = complex(rand(N),rand(N))
+        alm1 = Alm(lmax′,mmax′,x)
+        alm2 = Alm(lmax′,mmax′,y)
+        @test coefficients(alm1+alm2) == x+y
+        @test coefficients(alm1-alm2) == x-y
+    end
+
+    let
+        alm = Alm(Complex128, 5, 5)
+        rand!(alm.alm)
+        alm′ = LibHealpix.to_julia(LibHealpix.to_cxx(alm))
+        @test alm == alm′
+    end
+end
+

--- a/test/map.jl
+++ b/test/map.jl
@@ -38,6 +38,25 @@
         @test isnest(map)
     end
 
+    let nside = 16
+        map = HealpixMap(Float64,nside,LibHealpix.ring)
+        map[1] = 1
+        @test map[1] == pixels(map)[1] == 1
+        map[2] = 2
+        @test map[2] == pixels(map)[2] == 2
+
+        a = rand(Float64)
+        b = rand(Complex128)
+        x = rand(Float64, nside2npix(nside))
+        y = rand(Float64, nside2npix(nside))
+        map1 = HealpixMap(x)
+        map2 = HealpixMap(y)
+        @test pixels(map1+map2) == x+y
+        @test pixels(map1-map2) == x-y
+        @test pixels(a*map1) == pixels(map1*a) == a*x
+        @test_throws MethodError b*map1
+    end
+
     let
         for order in (LibHealpix.ring, LibHealpix.nest)
             map = HealpixMap(Float64, 512, order)

--- a/test/map.jl
+++ b/test/map.jl
@@ -1,0 +1,70 @@
+@testset "map.jl" begin
+    let
+        @test_throws DimensionMismatch HealpixMap{Float64,2,LibHealpix.ring}(zeros(Float64,5))
+
+        nside′ = 16
+        npix′ = nside2npix(nside′)
+
+        map = HealpixMap(nside′,LibHealpix.ring,zeros(npix′))
+        @test npix(map) == npix′ == length(map)
+        @test nside(map) == nside′
+        @test isring(map)
+        @test !isnest(map)
+
+        map = HealpixMap(Float64,nside′)
+        @test npix(map) == npix′ == length(map)
+        @test nside(map) == nside′
+        @test isring(map)
+        @test !isnest(map)
+        @test pixels(map) == zeros(Float64,npix′)
+
+        map = HealpixMap(Float64,nside′,LibHealpix.nest)
+        @test npix(map) == npix′ == length(map)
+        @test nside(map) == nside′
+        @test !isring(map)
+        @test isnest(map)
+        @test pixels(map) == zeros(Float64,npix′)
+
+        map = HealpixMap(zeros(npix′))
+        @test npix(map) == npix′ == length(map)
+        @test nside(map) == nside′
+        @test isring(map)
+        @test !isnest(map)
+
+        map = HealpixMap(zeros(npix′), LibHealpix.nest)
+        @test npix(map) == npix′ == length(map)
+        @test nside(map) == nside′
+        @test !isring(map)
+        @test isnest(map)
+    end
+
+    let
+        for order in (LibHealpix.ring, LibHealpix.nest)
+            map = HealpixMap(Float64, 512, order)
+            rand!(map.pixels)
+            map′ = LibHealpix.to_julia(LibHealpix.to_cxx(map))
+            @test map == map′
+        end
+    end
+
+    let nside = 16
+        filename = tempname()*".fits"
+        map = HealpixMap(Float32,nside)
+        for i = 1:length(map)
+            map[i] = rand()
+        end
+        writehealpix(filename,map)
+        newmap = readhealpix(filename)
+        @test map == newmap
+        @test_throws ErrorException writehealpix(filename,map)
+
+        # try with nest ordering instead
+        filename = tempname()*".fits"
+        map = HealpixMap(pixels(map), LibHealpix.nest)
+        writehealpix(filename,map)
+        newmap = readhealpix(filename)
+        @test map == newmap
+        @test_throws ErrorException writehealpix(filename,map)
+    end
+end
+

--- a/test/mollweide.jl
+++ b/test/mollweide.jl
@@ -1,0 +1,23 @@
+@testset "mollweide.jl" begin
+    let nside = 5
+        map = HealpixMap(Float64, nside)
+        for i = 1:length(map)
+            map[i] = 1.0
+        end
+        img = mollweide(map)'
+        N = size(img,2)
+        expected_img = zeros(2N,1N)
+        # Verify that the image is unity inside and zero outside
+        x = linspace(-2+1/N,2-1/N,2N)
+        y = linspace(-1+1/N,1-1/N,1N)
+        for j = 1:N, i = 1:2N
+            if x[i]^2 + 4y[j]^2 > 4
+                expected_img[i,j] = 0
+            else
+                expected_img[i,j] = 1
+            end
+        end
+        @test img == expected_img
+    end
+end
+

--- a/test/pixel.jl
+++ b/test/pixel.jl
@@ -1,0 +1,33 @@
+@testset "pixel.jl" begin
+    for nside = 1:5
+        npix = 12*nside^2
+        @test nside2npix(nside) == npix
+        @test npix2nside(npix) == nside
+    end
+
+    for θ in [0.5:0.5:3.0;], ϕ in [0.0:1.0:6.0;]
+        vec = LibHealpix.ang2vec(θ,ϕ)
+        θ′,ϕ′ = LibHealpix.vec2ang(vec)
+        @test θ ≈ θ′
+        @test ϕ ≈ ϕ′
+    end
+
+    let nside = 512
+        pix = 123
+        θ,ϕ = LibHealpix.pix2ang_nest(nside,pix)
+        @test LibHealpix.ang2pix_nest(nside,θ,ϕ) == pix
+        θ,ϕ = LibHealpix.pix2ang_ring(nside,pix)
+        @test LibHealpix.ang2pix_ring(nside,θ,ϕ) == pix
+        vec = LibHealpix.pix2vec_nest(nside,pix)
+        @test LibHealpix.vec2pix_nest(nside,vec) == pix
+        vec = LibHealpix.pix2vec_ring(nside,pix)
+        @test LibHealpix.vec2pix_ring(nside,vec) == pix
+    end
+
+    let nside = 4
+        for i = 1:LibHealpix.nside2npix(nside)
+            @test LibHealpix.nest2ring(nside,LibHealpix.ring2nest(nside,i)) == i
+        end
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,157 +1,17 @@
 using LibHealpix
-using Base.Test
+if VERSION >= v"0.5-"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 
 srand(123)
-
-for nside = 1:5
-    npix = 12*nside^2
-    @test LibHealpix.nside2npix(nside) == npix
-    @test LibHealpix.npix2nside(npix) == nside
-end
-
-for θ in [0.5:0.5:3.0;], ϕ in [0.0:1.0:6.0;]
-    vec = LibHealpix.ang2vec(θ,ϕ)
-    θ′,ϕ′ = LibHealpix.vec2ang(vec)
-    @test θ ≈ θ′
-    @test ϕ ≈ ϕ′
-end
-
-let nside = 512
-    pix = 123
-    θ,ϕ = LibHealpix.pix2ang_nest(nside,pix)
-    @test LibHealpix.ang2pix_nest(nside,θ,ϕ) == pix
-    θ,ϕ = LibHealpix.pix2ang_ring(nside,pix)
-    @test LibHealpix.ang2pix_ring(nside,θ,ϕ) == pix
-    vec = LibHealpix.pix2vec_nest(nside,pix)
-    @test LibHealpix.vec2pix_nest(nside,vec) == pix
-    vec = LibHealpix.pix2vec_ring(nside,pix)
-    @test LibHealpix.vec2pix_ring(nside,vec) == pix
-end
-
-let nside = 16
-    for i = 1:LibHealpix.nside2npix(nside)
-        @test LibHealpix.nest2ring(nside,LibHealpix.ring2nest(nside,i)) == i
-    end
-end
-
-let nside = 16
-    npix = LibHealpix.nside2npix(nside)
-    map = HealpixMap(rand(npix))
-    alm = map2alm(map,lmax=25,mmax=25)
-
-    # Note that the algorithm used by alm2map/map2alm isn't
-    # particularly accurate, hence the rough tolerance
-    map1 = alm2map(alm)
-    map2 = alm2map(map2alm(map1))
-    @test vecnorm(LibHealpix.pixels(map1)-LibHealpix.pixels(map2))/vecnorm(LibHealpix.pixels(map1)) < 0.01
-end
-
-# Test HealpixMap
-let
-    @test_throws DimensionMismatch HealpixMap{Float64,2,LibHealpix.ring}(zeros(Float64,5))
-
-    nside′ = 16
-    npix′ = nside2npix(nside′)
-
-    map = HealpixMap(nside′,LibHealpix.ring,zeros(npix′))
-    @test npix(map) == npix′ == length(map)
-    @test nside(map) == nside′
-    @test isring(map)
-    @test !isnest(map)
-
-    map = HealpixMap(Float64,nside′)
-    @test npix(map) == npix′ == length(map)
-    @test nside(map) == nside′
-    @test isring(map)
-    @test !isnest(map)
-    @test pixels(map) == zeros(Float64,npix′)
-
-    map = HealpixMap(Float64,nside′,LibHealpix.nest)
-    @test npix(map) == npix′ == length(map)
-    @test nside(map) == nside′
-    @test !isring(map)
-    @test isnest(map)
-    @test pixels(map) == zeros(Float64,npix′)
-
-    map = HealpixMap(zeros(npix′))
-    @test npix(map) == npix′ == length(map)
-    @test nside(map) == nside′
-    @test isring(map)
-    @test !isnest(map)
-
-    map = HealpixMap(zeros(npix′);order=LibHealpix.nest)
-    @test npix(map) == npix′ == length(map)
-    @test nside(map) == nside′
-    @test !isring(map)
-    @test isnest(map)
-end
-
-# Test FITS I/O
-let nside = 16
-    filename = tempname()*".fits"
-    map = HealpixMap(Float32,nside)
-    for i = 1:length(map)
-        map[i] = rand()
-    end
-    writehealpix(filename,map)
-    newmap = readhealpix(filename)
-    @test map == newmap
-    @test_throws ErrorException writehealpix(filename,map)
-
-    # try with nest ordering instead
-    filename = tempname()*".fits"
-    map = HealpixMap(pixels(map);order=LibHealpix.nest)
-    writehealpix(filename,map)
-    newmap = readhealpix(filename)
-    @test map == newmap
-    @test_throws ErrorException writehealpix(filename,map)
-end
-
-# Test Alm
-let
-    @test_throws DomainError Alm{Complex128,5,10}(zeros(Complex128,5))
-    @test_throws DimensionMismatch Alm{Complex128,10,5}(zeros(Complex128,5))
-
-    lmax′ = 10
-    mmax′ = 5
-    N = LibHealpix.num_alm(lmax′,mmax′)
-
-    alm = Alm{Complex128,lmax′,mmax′}(zeros(Complex128,N))
-    @test lmax(alm) == lmax′
-    @test mmax(alm) == mmax′
-
-    alm = Alm(Complex128,lmax′,mmax′)
-    @test lmax(alm) == lmax′
-    @test mmax(alm) == mmax′
-    @test coefficients(alm) == zeros(Complex128,N)
-    alm[0,0] = 1
-    @test alm[0,0] == coefficients(alm)[1] == 1
-
-    x = complex(rand(N),rand(N))
-    y = complex(rand(N),rand(N))
-    alm1 = Alm(lmax′,mmax′,x)
-    alm2 = Alm(lmax′,mmax′,y)
-    @test coefficients(alm1+alm2) == x+y
-    @test coefficients(alm1-alm2) == x-y
-end
-
-# Test the Mollweide projection
-let nside = 5
-    map = HealpixMap(Float64,nside)
-    for i = 1:length(map)
-        map[i] = 1.0
-    end
-    img = mollweide(map)'
-    # Verify that the image is unity inside and zero outside
-    N = size(img,2)
-    x = linspace(-2+1/N,2-1/N,2N)
-    y = linspace(-1+1/N,1-1/N,1N)
-    for j = 1:N, i = 1:2N
-        if x[i]^2 + 4y[j]^2 > 4
-            @test img[i,j] == 0
-        else
-            @test img[i,j] == 1
-        end
-    end
+@testset "LibHealpix Tests" begin
+    include("pixel.jl")
+    include("map.jl")
+    include("alm.jl")
+    include("transforms.jl")
+    include("mollweide.jl")
 end
 

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -1,0 +1,24 @@
+@testset "transforms.jl" begin
+    let nside = 16, lmax = 25, mmax = 25
+        npix = nside2npix(nside)
+        map = HealpixMap(rand(npix))
+        alm = map2alm(map, lmax, mmax)
+
+        # Note that the algorithm used by map2alm isn't particularly great
+        # with no iterations (hence the rough tolerance)
+        map1 = alm2map(alm, nside)
+        map2 = alm2map(map2alm(map1, lmax, mmax), nside)
+        @test vecnorm(pixels(map1)-pixels(map2))/vecnorm(pixels(map1)) < 1e-2
+
+        # With more iterations we should be able to do better
+        map2 = alm2map(map2alm(map1, lmax, mmax, iterations = 1), nside)
+        @test vecnorm(pixels(map1)-pixels(map2))/vecnorm(pixels(map1)) < 1e-3
+        map2 = alm2map(map2alm(map1, lmax, mmax, iterations = 2), nside)
+        @test vecnorm(pixels(map1)-pixels(map2))/vecnorm(pixels(map1)) < 1e-4
+        map2 = alm2map(map2alm(map1, lmax, mmax, iterations = 3), nside)
+        @test vecnorm(pixels(map1)-pixels(map2))/vecnorm(pixels(map1)) < 1e-5
+        map2 = alm2map(map2alm(map1, lmax, mmax, iterations = 10), nside)
+        @test vecnorm(pixels(map1)-pixels(map2))/vecnorm(pixels(map1)) < 1e-12
+    end
+end
+


### PR DESCRIPTION
This is 90% minor formatting changes.
- fix #17 
- preserve the ordering scheme in `to_julia` and `to_cxx` for `HealpixMap`s
- wrap the iterative `map2alm` (I've wanted this for a while)
- deprecate keyword arguments to `HealpixMap`, `map2alm`, and `alm2map` because giving them a default value seems like the wrong thing to do
- use `BaseTestNext` in the tests
