### PR TITLE
julia implementation of interpolation (and other assorted changes)

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -83,8 +83,8 @@ provides(SimpleBuild,
               end
           end), libcfitsio)
 
-version = "3.30"
-date = "2015Oct08"
+version = "3.31"
+date = "2016Aug26"
 tar = "Healpix_$(version)_$date.tar.gz"
 url = "http://downloads.sourceforge.net/project/healpix/Healpix_$version/$tar"
 libhealpix_src_directory = joinpath(BinDeps.depsdir(libchealpix), "src", "Healpix_$version")

--- a/deps/src/wrapper/wrapper.cpp
+++ b/deps/src/wrapper/wrapper.cpp
@@ -88,11 +88,7 @@ T interpolate(int nside, int order, T* pixels, double theta, double phi)
 {
     auto map = construct_healpix_map(nside, order, pixels);
     auto ptg = pointing(theta, phi);
-    auto pix = fix_arr<int, 4>();    // the index of the 4 nearest pixels
-    auto wgt = fix_arr<double, 4>(); // the weights for the 4 nearest pixels
-    map.get_interpol(ptg, pix, wgt);
-    return wgt[0]*map[pix[0]] + wgt[1]*map[pix[1]]
-            + wgt[2]*map[pix[2]] + wgt[3]*map[pix[3]];
+    return map.interpolated_value(ptg);
 }
 
 extern "C" {

--- a/src/LibHealpix.jl
+++ b/src/LibHealpix.jl
@@ -65,6 +65,7 @@ function Base.show(io::IO, exception::LibHealpixException)
 end
 
 include("pixel.jl")
+include("rings.jl")
 include("map.jl")
 include("alm.jl")
 include("transforms.jl")

--- a/src/rings.jl
+++ b/src/rings.jl
@@ -1,0 +1,72 @@
+# Copyright (c) 2015-2017 Michael Eastwood
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Functions in this file are translated from C++ to Julia (mostly verbatim) from Healpix_cxx.
+# Healpix_cxx is licensed under GPL-2.0 or later.
+
+doc"""
+Returns the number of the next ring to the north of $z=\cos(θ)$.  It may return 0; in this case $z$
+lies north of all rings.
+
+Note that in some cases, due to floating point rounding errors, the ring may be south of $z$.
+"""
+function ring_above(nside, z)
+    az = abs(z)
+    if az < 2/3 # equatorial region
+        return trunc(Int, nside*(2-1.5*z))
+    else
+        ring = trunc(Int, nside*sqrt(3*(1-az)))
+        return z>0 ? ring : 4nside-ring-1
+    end
+end
+
+doc"""
+Returns useful information about a given ring of the map.
+
+- `ring` - the ring number (the number of the first ring is 1)
+- `startpix` - the number of the first pixel in the ring
+  (NOTE: this is always given in the RING numbering scheme!)
+- `ringpix` - the number of pixels in the ring
+- `θ` - the colatitude (in radians) of the ring
+- `shifted` - if `true`, the center of the first pixel is not at $ϕ=0$
+"""
+function ring_info2(nside, ring)
+    northring = ring>2nside ? 4nside-ring : ring
+    npix   = nside2npix(nside) # total number of pixels
+    npface = nside*nside       # number of pixels per face
+    ncap   = (npface-nside)<<1 # number of pixels in the polar cap
+    fact2 = 4/npix
+    fact1 = (nside<<1)*fact2
+    if northring < nside
+        tmp = northring*northring*fact2
+        cosθ = 1 - tmp
+        sinθ = sqrt(tmp*(2-tmp))
+        θ = atan2(sinθ, cosθ)
+        ringpix = 4northring
+        shifted = true
+        startpix = 2northring*northring - 1
+    else
+        θ = acos((2nside-northring)*fact1)
+        ringpix = 4nside
+        shifted = ((northring-nside) & 1) == 0
+        startpix = ncap + (northring-nside)*ringpix + 1
+    end
+    if northring != ring # southern hemisphere
+        θ = π - θ
+        startpix = npix - startpix - ringpix + 2
+    end
+    startpix, ringpix, θ, shifted
+end
+

--- a/src/rings.jl
+++ b/src/rings.jl
@@ -14,7 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Functions in this file are translated from C++ to Julia (mostly verbatim) from Healpix_cxx.
-# Healpix_cxx is licensed under GPL-2.0 or later.
+# Healpix_cxx is licensed under GPL-2.0 or later, and is developed by the Max-Planck-Institut fuer
+# Astrophysik.
 
 doc"""
 Returns the number of the next ring to the north of $z=\cos(θ)$.  It may return 0; in this case $z$

--- a/test/map.jl
+++ b/test/map.jl
@@ -173,8 +173,7 @@
     @testset "interpolate" begin
         add2pi(θ, ϕ) = (θ, ϕ+2π)
         sub2pi(θ, ϕ) = (θ, ϕ-2π)
-        #for T in (Float32, Float64), M in (RingHealpixMap, NestHealpixMap)
-        for T in (Float64,), M in (RingHealpixMap,)
+        for T in (Float32, Float64), M in (RingHealpixMap, NestHealpixMap)
             map = M(T, 2)
             map[:] = rand(T, length(map))
             if LibHealpix.ordering(map) == LibHealpix.ring

--- a/test/map.jl
+++ b/test/map.jl
@@ -171,14 +171,38 @@
     end
 
     @testset "interpolate" begin
-        for T in (Float32, Float64)
-            map = RingHealpixMap(T, 4)
-            map[1] = rand(T)
-            map[2] = rand(T)
-            map[3] = rand(T)
-            map[4] = rand(T)
-            expected = (map[1] + map[2] + map[3] + map[4])/4
-            @test LibHealpix.interpolate(map, 0, 0) === expected
+        add2pi(θ, ϕ) = (θ, ϕ+2π)
+        sub2pi(θ, ϕ) = (θ, ϕ-2π)
+        #for T in (Float32, Float64), M in (RingHealpixMap, NestHealpixMap)
+        for T in (Float64,), M in (RingHealpixMap,)
+            map = M(T, 2)
+            map[:] = rand(T, length(map))
+            if LibHealpix.ordering(map) == LibHealpix.ring
+                expected = (map[1] + map[2] + map[3] + map[4])/4
+            else
+                expected = (map[4] + map[8] + map[12] + map[16])/4
+            end
+            @test isapprox(LibHealpix.interpolate(map, 0, 0), T(expected), atol=2e-15)
+
+            interpolation = [LibHealpix.interpolate(map, pix2ang(map, idx)...)
+                                for idx = 1:length(map)]
+            @test all(isapprox.(map, interpolation, atol=2e-15))
+
+            interpolation = [LibHealpix.interpolate(map, add2pi(pix2ang(map, idx)...)...)
+                                for idx = 1:length(map)]
+            @test all(isapprox.(map, interpolation, atol=2e-15))
+
+            interpolation = [LibHealpix.interpolate(map, sub2pi(pix2ang(map, idx)...)...)
+                                for idx = 1:length(map)]
+            @test all(isapprox.(map, interpolation, atol=2e-15))
+
+            # Check the interpolation procedure against the C++ implementation
+            # (note the C++ implementation seems to have a bug near 2π, so we don't test exactly
+            # there, but that case should be covered above)
+            for θ in (0.0, 1.0, π/2, 2.0, π), ϕ in (0.0, 1.0, π, 4.0, 2π-0.001)
+                @test isapprox(LibHealpix.interpolate(map, θ, ϕ),
+                               LibHealpix.interpolate_cxx(map, θ, ϕ), atol=2e-15)
+            end
         end
     end
 

--- a/test/rings.jl
+++ b/test/rings.jl
@@ -47,7 +47,7 @@
             @test isapprox(stop_θ, θ, atol=1e-15)
             @test start_ϕ < stop_ϕ
             if shifted
-                @test start_ϕ > 0
+                @test start_ϕ == π/ringpix
             else
                 @test start_ϕ == 0
             end

--- a/test/rings.jl
+++ b/test/rings.jl
@@ -1,0 +1,57 @@
+# Copyright (c) 2015-2017 Michael Eastwood
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+@testset "rings.jl" begin
+    @testset "ring_above" begin
+        z = cos(0.8410686705679303)
+        @test LibHealpix.ring_above(1, z) === 1
+        @test LibHealpix.ring_above(1, nextfloat(z)) === 0
+
+        z = cos(1.5707963267948966)
+        @test LibHealpix.ring_above(1, z) === 2
+        @test_broken LibHealpix.ring_above(1, nextfloat(z)) === 1
+
+        z = cos(2.300523983021863)
+        @test LibHealpix.ring_above(1, z) === 3
+        @test LibHealpix.ring_above(1, nextfloat(z)) === 2
+
+        @test LibHealpix.ring_above(1, +1) === 0
+        @test LibHealpix.ring_above(1,  0) === 2
+        @test LibHealpix.ring_above(1, -1) === 3
+    end
+
+    @testset "ring_info2" begin
+        nside = 2
+        npix  = nside2npix( nside)
+        nring = nside2nring(nside)
+        for ring = 1:nring
+            startpix, ringpix, θ, shifted = LibHealpix.ring_info2(nside, ring)
+            stoppix = startpix + ringpix - 1
+            @test startpix ≥ 1
+            @test stoppix ≤ npix
+            start_θ, start_ϕ = pix2ang_ring(nside, startpix)
+            stop_θ, stop_ϕ = pix2ang_ring(nside, stoppix)
+            @test isapprox(start_θ, θ, atol=1e-15)
+            @test isapprox(stop_θ, θ, atol=1e-15)
+            @test start_ϕ < stop_ϕ
+            if shifted
+                @test start_ϕ > 0
+            else
+                @test start_ϕ == 0
+            end
+        end
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ using FITSIO.Libcfitsio
 srand(123)
 @testset "LibHealpix Tests" begin
     include("pixel.jl")
+    include("rings.jl")
     include("map.jl")
     include("alm.jl")
     include("transforms.jl")


### PR DESCRIPTION
* upgrade to Healpix 3.31 (fixes #36)
* use verify_angles with interpolation query_disc (fixes #40)
* replaces the C++ wrapper of interpolation with a Julia implementation. This fixes a bug when interpolating near phi=2pi and as a bonus seems to be about 30% faster (not entirely sure why). I should really upstream a patch that fixes this, but I'm swamped at the moment.

I still need to update the pre-compiled binaries, but otherwise I think this is good to go.