### PR TITLE
fix for custom broadcast operations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # News
 
+## v0.2.6
+
+*unreleased*
+
+* Bugfix for broadcasting operations like `.+=` and `.=`
+
 ## v0.2.5
 
 *2017-11-13*

--- a/src/alm.jl
+++ b/src/alm.jl
@@ -288,6 +288,7 @@ Base.:(==)(lhs::Alm, rhs::AbstractVector) = false
 Base.:(==)(lhs::AbstractVector, rhs::Alm) = false
 
 # Custom broadcasting
+Base.Broadcast.broadcast_indices(::Type{<:Alm}, alm) = indices(alm)
 Base.Broadcast._containertype(::Type{<:Alm}) = Alm
 Base.Broadcast.promote_containertype(::Type{Any}, ::Type{Alm}) = Alm
 Base.Broadcast.promote_containertype(::Type{Alm}, ::Type{Any}) = Alm

--- a/src/map.jl
+++ b/src/map.jl
@@ -303,6 +303,7 @@ Base.:(==)(lhs::HealpixMap, rhs::AbstractVector) = false
 Base.:(==)(lhs::AbstractVector, rhs::HealpixMap) = false
 
 # Custom broadcasting
+Base.Broadcast.broadcast_indices(::Type{<:HealpixMap}, map) = indices(map)
 Base.Broadcast._containertype(::Type{<:RingHealpixMap}) = RingHealpixMap
 Base.Broadcast._containertype(::Type{<:NestHealpixMap}) = NestHealpixMap
 Base.Broadcast.promote_containertype(::Type{Any}, ::Type{T}) where {T<:HealpixMap} = T

--- a/test/alm.jl
+++ b/test/alm.jl
@@ -154,6 +154,14 @@
         @test f.(1, alm, alm) == Alm(lmax, mmax, f.(1, coefficients, coefficients))
         @test f.(alm, alm, alm) == Alm(lmax, mmax, f.(coefficients, coefficients, coefficients))
         @inferred broadcast(f, alm, alm, alm)
+
+        alm1 = Alm(Complex128, lmax, mmax)
+        rand!(alm1.coefficients)
+        alm2 = deepcopy(alm1)
+        alm1 .+= 1
+        @test alm1 == alm2 .+ 1
+        alm1 .= sin.(alm1)
+        @test alm1 == sin.(alm2 .+ 1)
     end
 end
 

--- a/test/map.jl
+++ b/test/map.jl
@@ -167,6 +167,13 @@
             @test f.(1, map, map) == Map(nside, f.(1, pixels, pixels))
             @test f.(map, map, map) == Map(nside, f.(pixels, pixels, pixels))
             @inferred broadcast(f, map, map, map)
+
+            map1 = Map(nside, randn(npix))
+            map2 = deepcopy(map1)
+            map1 .+= 1
+            @test map1 == map2 .+ 1
+            map1 .= sin.(map1)
+            @test map1 == sin.(map2 .+ 1)
         end
     end
 


### PR DESCRIPTION
I came across a problem where this would produce a stack overflow:
```julia
x = RingHealpixMap(Float64, 1)
x .+= 1
```
This fixes that problem and adds some tests.